### PR TITLE
make build fail if XML comments are missing or invalid

### DIFF
--- a/src/LaunchDarkly.Logging/LaunchDarkly.Logging.csproj
+++ b/src/LaunchDarkly.Logging/LaunchDarkly.Logging.csproj
@@ -16,6 +16,9 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+
+    <!-- fail if XML comments are missing or invalid -->
+    <WarningsAsErrors>1570,1571,1572,1573,1574,1580,1581,1584,1591,1710,1711,1712</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">


### PR DESCRIPTION
This causes a build error, rather than the default behavior of a warning, for the following conditions:

* An XML comment is malformed, like it's not valid XML at all (1570)
* A `<param>` tag was omitted, duplicated, or had an unknown name (1571, 1572, 1573)
* A `cref` link specified an unknown symbol or had a syntax error (1574, 1580, 1584)
* A `<returns>` tag specified an unknown type (1581)
* A public type, method, or property doesn't have an XML comment (1591)
* A `<typeparam>` tag was omitted, duplicated, or had an unknown name (1710, 1711, 1712)

Unfortunately, there are several kinds of mistakes it _can't_ detect:

* If you misspell a tag, as long as the closing tag is identically misspelled (like `<summar>...</summar>` instead of `<summary>`), it assumes that that's just HTML and lets it be.
* If you omit _all_ the `<param>` or `<typeparam>` tags for a method, it's OK with that. It only complains if you provide tags for some of the parameters but not all.

I may have missed some error codes since there doesn't seem to be a single list showing all of the XML-comment-related ones.