### PR TITLE
drop .NET Core 2.1 and .NET Framework 4.5.2/4.6.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,37 +1,37 @@
 version: 2.1
 
+orbs:
+  win: circleci/windows@1.0.0
+
 workflows:
   version: 2
   test:
     jobs:
-      - build-netstandard-netcore
-      - test-netcore:
+      - build_all
+      - test_linux:
           name: .NET Core 2.1
           docker-image: mcr.microsoft.com/dotnet/core/sdk:2.1-focal
           test-target-framework: netcoreapp2.1
           requires:
-            - build-netstandard-netcore
-      - test-netcore:
+            - build_all
+      - test_linux:
           name: .NET Core 2.1 library running in .NET Core 3.1
           docker-image: mcr.microsoft.com/dotnet/core/sdk:3.1-focal
           test-target-framework: netcoreapp3.1
           requires:
-            - build-netstandard-netcore
-      - test-netcore:
-          name: .NET Core 2.1 library running in .NET 5.0
-          docker-image: mcr.microsoft.com/dotnet/sdk:5.0-focal
-          test-target-framework: net5.0
+            - build_all
+      - test_linux:
+          name: .NET Core 2.1 library running in .NET 6.0
+          docker-image: mcr.microsoft.com/dotnet/sdk:6.0-focal
+          test-target-framework: net6.0
           requires:
-            - build-netstandard-netcore
-      - test-windows-netframework-4-5-2
-
-orbs:
-  win: circleci/windows@1.0.0
+            - build_all
+      - test_windows
 
 jobs:
-  build-netstandard-netcore:
+  build_all:
     docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:2.1-focal
+      - image: mcr.microsoft.com/dotnet/core/sdk:3.1-focal
     environment:
       ASPNETCORE_SUPPRESSSTATUSMESSAGES: true
     steps:
@@ -43,15 +43,15 @@ jobs:
           name: build .NET Standard 2.0
           command: dotnet build src/LaunchDarkly.Logging -f netstandard2.0
       - run:
-          name: build .NET Core 2.1
-          command: dotnet build src/LaunchDarkly.Logging -f netcoreapp2.1
+          name: build .NET Core 3.1
+          command: dotnet build src/LaunchDarkly.Logging -f netcoreapp3.1
       - persist_to_workspace:
           root: src/LaunchDarkly.Logging
           paths:
             - bin
             - obj
 
-  test-netcore:
+  test_linux:
     parameters:
       docker-image:
         type: string
@@ -70,27 +70,27 @@ jobs:
           name: run tests
           command: dotnet test test/LaunchDarkly.Logging.Tests/LaunchDarkly.Logging.Tests.csproj -f <<parameters.test-target-framework>>
 
-  test-windows-netframework-4-5-2:
+  test_windows:
     executor:
       name: win/vs2019
       shell: powershell.exe
     environment:
-      TESTFRAMEWORK: net452
+      TESTFRAMEWORK: net462
     steps:
       - checkout
       - restore_cache:
           keys: 
-            - net452-deps-{{ checksum "src/LaunchDarkly.Logging/LaunchDarkly.Logging.csproj" }}-{{ checksum "test/LaunchDarkly.Logging.Tests/LaunchDarkly.Logging.Tests.csproj" }}
+            - net462-deps-{{ checksum "src/LaunchDarkly.Logging/LaunchDarkly.Logging.csproj" }}-{{ checksum "test/LaunchDarkly.Logging.Tests/LaunchDarkly.Logging.Tests.csproj" }}
       - run:
           name: install project dependencies
           command: dotnet restore
       - save_cache:
-          key: net452-deps-{{ checksum "src/LaunchDarkly.Logging/LaunchDarkly.Logging.csproj" }}-{{ checksum "test/LaunchDarkly.Logging.Tests/LaunchDarkly.Logging.Tests.csproj" }}
+          key: net462-deps-{{ checksum "src/LaunchDarkly.Logging/LaunchDarkly.Logging.csproj" }}-{{ checksum "test/LaunchDarkly.Logging.Tests/LaunchDarkly.Logging.Tests.csproj" }}
           paths:
             - C:\Users\circleci\.nuget\packages
       - run:
           name: build
-          command: dotnet build src/LaunchDarkly.Logging -f net452
+          command: dotnet build src/LaunchDarkly.Logging -f net462
       - run:
           name: run tests
-          command: dotnet test test/LaunchDarkly.Logging.Tests/LaunchDarkly.Logging.Tests.csproj -f net452
+          command: dotnet test test/LaunchDarkly.Logging.Tests/LaunchDarkly.Logging.Tests.csproj -f net462

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,19 +9,13 @@ workflows:
     jobs:
       - build_all
       - test_linux:
-          name: .NET Core 2.1
-          docker-image: mcr.microsoft.com/dotnet/core/sdk:2.1-focal
-          test-target-framework: netcoreapp2.1
-          requires:
-            - build_all
-      - test_linux:
-          name: .NET Core 2.1 library running in .NET Core 3.1
+          name: .NET Core 3.1
           docker-image: mcr.microsoft.com/dotnet/core/sdk:3.1-focal
           test-target-framework: netcoreapp3.1
           requires:
             - build_all
       - test_linux:
-          name: .NET Core 2.1 library running in .NET 6.0
+          name: .NET Core 3.1 library running in .NET 6.0
           docker-image: mcr.microsoft.com/dotnet/sdk:6.0-focal
           test-target-framework: net6.0
           requires:
@@ -75,6 +69,7 @@ jobs:
       name: win/vs2019
       shell: powershell.exe
     environment:
+      BUILDFRAMEWORKS: net462
       TESTFRAMEWORK: net462
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,11 @@ jobs:
           at: src/LaunchDarkly.Logging
       - run:
           name: run tests
-          command: dotnet test test/LaunchDarkly.Logging.Tests/LaunchDarkly.Logging.Tests.csproj -f <<parameters.test-target-framework>>
+          command: |
+              dotnet test \
+              -l "junit;LogFilePath=/tmp/circle-reports/unit-tests-commonsdk.xml" \
+              -f <<parameters.test-target-framework>> \
+              test/LaunchDarkly.Logging.Tests/LaunchDarkly.Logging.Tests.csproj
 
   test_windows:
     executor:
@@ -88,4 +92,7 @@ jobs:
           command: dotnet build src/LaunchDarkly.Logging -f net462
       - run:
           name: run tests
-          command: dotnet test test/LaunchDarkly.Logging.Tests/LaunchDarkly.Logging.Tests.csproj -f net462
+          command: |
+              dotnet test \
+              -l "junit;LogFilePath=/tmp/circle-reports/unit-tests-commonsdk.xml" \
+              test/LaunchDarkly.Logging.Tests/LaunchDarkly.Logging.Tests.csproj

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,8 @@ jobs:
               -l "junit;LogFilePath=/tmp/circle-reports/unit-tests-commonsdk.xml" \
               -f <<parameters.test-target-framework>> \
               test/LaunchDarkly.Logging.Tests/LaunchDarkly.Logging.Tests.csproj
+      - store_test_results:
+          path: /tmp/circle-reports
 
   test_windows:
     executor:
@@ -96,3 +98,5 @@ jobs:
               dotnet test \
               -l "junit;LogFilePath=/tmp/circle-reports/unit-tests-commonsdk.xml" \
               test/LaunchDarkly.Logging.Tests/LaunchDarkly.Logging.Tests.csproj
+      - store_test_results:
+          path: /tmp/circle-reports

--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -7,10 +7,14 @@ publications:
 jobs:
   - docker: {}
     template:
-      name: dotnet-linux
+      name: dotnet6-linux
     env:
-      LD_RELEASE_TEST_TARGET_FRAMEWORK: net50
-      LD_RELEASE_DOCS_TARGET_FRAMEWORK: netcoreapp2.1 # so the docs will include Logs.CoreLogging
+      LD_RELEASE_TEST_TARGET_FRAMEWORK: net6.0
+      LD_RELEASE_DOCS_TARGET_FRAMEWORK: netcoreapp3.1 # so the docs will include Logs.CoreLogging
+
+branches:
+  - name: main
+  - name: 1.x
 
 documentation:
   title: LaunchDarkly Logging API for .NET

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ For more information and examples, see the [API documentation](https://launchdar
 
 This version of the library is built for the following targets:
 
-* .NET Framework 4.5.2: runs on .NET Framework 4.5.x and above.
-* .NET Core 2.1: runs on .NET Core 2.x and 3.x, or .NET 5. This target provides an adapter to the standard .NET Core logging framework, `Logs.CoreLogging`, which is not available in .NET Framework.
+* .NET Framework 4.6.2: runs on .NET Framework 4.6.2 and above.
+* .NET Core 3.1: runs on .NET Core 3.x, or .NET 6.0+. This target provides an adapter to the standard .NET Core logging framework, `Logs.CoreLogging`, which is not available in .NET Framework except as a separate package.
 * .NET Standard 2.0: runs on application platforms that are neither of the above, such as Xamarin, or within a library that is targeted to .NET Standard 2.x.
 
 The .NET build tools should automatically load the most appropriate build of the library for whatever platform your application or library is targeted to.

--- a/src/LaunchDarkly.Logging/LaunchDarkly.Logging.csproj
+++ b/src/LaunchDarkly.Logging/LaunchDarkly.Logging.csproj
@@ -1,7 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Version>1.0.1</Version>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net462</TargetFrameworks>
+    <!--
+      The reason there's a mechanism here for overriding the target frameworks with
+      an environment variable is that we want to be able to run CI tests using .NET
+      SDKs that may not support all of these target frameworks.
+    -->
+    <BuildFrameworks Condition="'$(BUILDFRAMEWORKS)' == ''">netstandard2.0;netcoreapp3.1;net462</BuildFrameworks>
+    <TargetFrameworks>$(BUILDFRAMEWORKS)</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>LaunchDarkly.Logging</AssemblyName>
     <OutputType>Library</OutputType>

--- a/src/LaunchDarkly.Logging/LaunchDarkly.Logging.csproj
+++ b/src/LaunchDarkly.Logging/LaunchDarkly.Logging.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Version>1.0.1</Version>
-    <TargetFrameworks>netstandard2.0;netcoreapp2.1;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net462</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>LaunchDarkly.Logging</AssemblyName>
     <OutputType>Library</OutputType>
@@ -21,8 +21,8 @@
     <WarningsAsErrors>1570,1571,1572,1573,1574,1580,1581,1584,1591,1710,1711,1712</WarningsAsErrors>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.9" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/LaunchDarkly.Logging/Logs.cs
+++ b/src/LaunchDarkly.Logging/Logs.cs
@@ -102,13 +102,21 @@ namespace LaunchDarkly.Logging
         /// </summary>
         /// <remarks>
         /// <para>
-        /// This method is only available when your target framework is .NET Core. It causes
+        /// This method is only available when your target framework is .NET Core or .NET 6.0+. It causes
         /// the <c>LaunchDarkly.Logging</c> APIs to delegate to the <c>Microsoft.Extensions.Logging</c>
         /// framework. The <c>ILoggingFactory</c> is the main configuration object for
         /// <c>Microsoft.Extensions.Logging</c>; application code can construct it programmatically,
         /// or can obtain it by dependency injection. For more information, see
         /// <see href="https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/?view=aspnetcore-3.1">Logging
         /// in .NET Core and ASP.NET Core</see>.
+        /// </para>
+        /// <para>
+        /// If you want to use <c>Microsoft.Extensions.Logging</c> on a different platform, such as
+        /// .NET Framework or a mobile OS, use the separate package
+        /// <a href="https://github.com/launchdarkly/dotnet-logging-adapter-ms">LaunchDarkly.Logging.Microsoft</a>.
+        /// The adapter is not built into <c>LaunchDarkly.Logging</c> on those platforms, to avoid
+        /// bringing in the <c>Microsoft.Extensions.Logging</c> package as a dependency that may not
+        /// be wanted.
         /// </para>
         /// <para>
         /// The .NET Core logging framework has its own mechanisms for filtering log output

--- a/test/LaunchDarkly.Logging.Tests/LaunchDarkly.Logging.Tests.csproj
+++ b/test/LaunchDarkly.Logging.Tests/LaunchDarkly.Logging.Tests.csproj
@@ -1,20 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TestFramework Condition="'$(TESTFRAMEWORK)' == ''">netcoreapp2.1;net5.0</TestFramework>
+    <TestFramework Condition="'$(TESTFRAMEWORK)' == ''">netcoreapp3.1;net6.0</TestFramework>
     <TargetFrameworks>$(TESTFRAMEWORK)</TargetFrameworks>
     <AssemblyName>LaunchDarkly.Logging.Tests</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.console" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="JunitXml.TestLogger" Version="3.0.114" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' 
-                      or '$(TargetFramework)' == 'netcoreapp3.1'
-                      or '$(TargetFramework)' == 'net5.0' ">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.9" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'
+                      or '$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This will be a new major version release of LaunchDarkly.Logging.