### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         id: release
         with:
           token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## Summary

Pin all third-party GitHub Actions to full-length commit SHAs to prevent supply chain attacks.

Addresses findings from the [`third-party-action-not-pinned-to-commit-sha`](https://github.com/launchdarkly/semgrep-rules/blob/main/github-actions/third-party-action-not-pinned-to-commit-sha.yml) Semgrep rule.

## Test plan

- [ ] Verify CI passes with pinned action SHAs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow hardening change that should not affect behavior, but it does touch the release automation path if the pinned commit differs from the expected `v4` tag.
> 
> **Overview**
> Pins `googleapis/release-please-action` in `.github/workflows/release-please.yml` from the floating `@v4` tag to a specific commit SHA to reduce GitHub Actions supply-chain risk.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8b96d8fd4303da50efe7206d4082fd0d5296c1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->