### PR TITLE
ci: migrate from SLSA provenance to actions/attest with subject-path

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -4,11 +4,6 @@ inputs:
   dry_run:
     description: 'Is this a dry run. If so no package will be published.'
     required: true
-outputs:
-  hashes:
-    description: sha256sum hashes of built artifacts
-    value: ${{ steps.hash.outputs.hashes }}
-
 runs:
   using: composite
   steps:
@@ -32,13 +27,6 @@ runs:
           dotnet nuget push "${pkg}" --api-key ${{ env.NUGET_API_KEY }} --source https://www.nuget.org
           echo "published ${pkg}"
         done
-
-    - name: Hash nuget packages
-      id: hash
-      if: ${{ inputs.dry_run == 'false' }}
-      shell: bash
-      run: |
-        echo "hashes=$(sha256sum ./nupkgs/*.nupkg ./nupkgs/*.snupkg | base64 -w0)" >> "$GITHUB_OUTPUT"
 
     - name: Dry Run Publish
       if: ${{ inputs.dry_run == 'true' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,15 +71,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           dry_run: ${{ inputs.dry_run }}
 
-      - name: Generate checksums file
-        if: ${{ inputs.dry_run == 'false' }}
-        env:
-          HASHES: ${{ steps.publish.outputs.hashes }}
-        run: |
-          echo "$HASHES" | base64 -d > checksums.txt
-
       - name: Attest build provenance
         if: ${{ inputs.dry_run == 'false' }}
         uses: actions/attest@v4
         with:
-          subject-checksums: checksums.txt
+          subject-path: 'nupkgs/*'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,7 +64,7 @@ jobs:
           dry_run: ${{ inputs.dry_run }}
 
       - name: Attest build provenance
-        if: ${{ inputs.dry_run == 'false' }}
+        if: ${{ format('{0}', inputs.dry_run) == 'false' }}
         uses: actions/attest@v4
         with:
           subject-path: 'nupkgs/*'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,9 +8,14 @@ on:
         type: boolean
         required: true
       tag:
-        description: 'Tag for provenance. For a dry run the value does not matter.'
+        description: 'Tag of an existing draft release. For a dry run the value does not matter.'
         type: string
         required: true
+      publish_release:
+        description: 'Publish (un-draft) the release after all artifacts are uploaded?'
+        type: boolean
+        required: false
+        default: true
 
   workflow_call:
     inputs:
@@ -22,6 +27,11 @@ on:
         description: 'Tag for provenance'
         type: string
         required: true
+      publish_release:
+        description: 'Publish (un-draft) the release after all artifacts are uploaded?'
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   publish:
@@ -84,3 +94,19 @@ jobs:
         uses: actions/attest@v4
         with:
           subject-checksums: checksums.txt
+
+  publish-release:
+    needs: ['publish']
+    if: ${{ !inputs.dry_run && inputs.publish_release }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ inputs.tag }}
+        run: >
+          gh release edit "$TAG_NAME"
+          --repo ${{ github.repository }}
+          --draft=false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,20 +7,12 @@ on:
         description: 'Is this a dry run. If so no package will be published.'
         type: boolean
         required: true
-      tag:
-        description: 'Tag for provenance. For a dry run the value does not matter.'
-        type: string
-        required: true
 
   workflow_call:
     inputs:
       dry_run:
         description: 'Is this a dry run. If so no package will be published.'
         type: boolean
-        required: true
-      tag:
-        description: 'Tag for provenance'
-        type: string
         required: true
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,14 +8,9 @@ on:
         type: boolean
         required: true
       tag:
-        description: 'Tag of an existing draft release. For a dry run the value does not matter.'
+        description: 'Tag for provenance. For a dry run the value does not matter.'
         type: string
         required: true
-      publish_release:
-        description: 'Publish (un-draft) the release after all artifacts are uploaded?'
-        type: boolean
-        required: false
-        default: true
 
   workflow_call:
     inputs:
@@ -27,11 +22,6 @@ on:
         description: 'Tag for provenance'
         type: string
         required: true
-      publish_release:
-        description: 'Publish (un-draft) the release after all artifacts are uploaded?'
-        type: boolean
-        required: false
-        default: false
 
 jobs:
   publish:
@@ -56,7 +46,6 @@ jobs:
             /production/common/releasing/digicert/code_signing_cert_sha1_hash = DIGICERT_CODE_SIGNING_CERT_SHA1_HASH,
             /production/common/releasing/nuget/api_key = NUGET_API_KEY'
           s3_path_pairs: 'launchdarkly-releaser/dotnet/LaunchDarkly.Logging.snk = LaunchDarkly.Logging.snk'
-
 
       - name: Build Release
         uses: ./.github/actions/release-build
@@ -94,19 +83,3 @@ jobs:
         uses: actions/attest@v4
         with:
           subject-checksums: checksums.txt
-
-  publish-release:
-    needs: ['publish']
-    if: ${{ !inputs.dry_run && inputs.publish_release }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Publish release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ inputs.tag }}
-        run: >
-          gh release edit "$TAG_NAME"
-          --repo ${{ github.repository }}
-          --draft=false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,7 @@ jobs:
       id-token: write # Needed if using OIDC to get release secrets.
       contents: write # Contents and pull-requests are for release-please to make releases.
       pull-requests: write
+      attestations: write
 
     steps:
       - uses: actions/checkout@v4
@@ -71,16 +72,15 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           dry_run: ${{ inputs.dry_run }}
 
-  provenance:
-    permissions:
-      actions: read
-      id-token: write
-      contents: write
-    if: ${{ inputs.dry_run  == 'false' }}
-    needs: ['publish']
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0
-    with:
-      base64-subjects: "${{ needs.publish.outputs.hashes }}"
-      upload-assets: true
-      upload-tag-name: ${{ inputs.tag }}
-      provenance-name: ${{ format('LaunchDarkly.Logging-{0}_provenance.intoto.jsonl', inputs.tag) }}
+      - name: Generate checksums file
+        if: ${{ inputs.dry_run == 'false' }}
+        env:
+          HASHES: ${{ steps.publish.outputs.hashes }}
+        run: |
+          echo "$HASHES" | base64 -d > checksums.txt
+
+      - name: Attest build provenance
+        if: ${{ inputs.dry_run == 'false' }}
+        uses: actions/attest@v4
+        with:
+          subject-checksums: checksums.txt

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,7 +9,6 @@ jobs:
   release-please:
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write # Needed if using OIDC to get release secrets.

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,14 +23,56 @@ jobs:
           token: ${{secrets.GITHUB_TOKEN}}
           default-branch: main
 
+  create-tag:
+    needs: ['release-please']
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create release tag
+        env:
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            echo "Tag ${TAG_NAME} already exists, skipping creation."
+          else
+            echo "Creating tag ${TAG_NAME}."
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "${TAG_NAME}"
+            git push origin "${TAG_NAME}"
+          fi
+
   ci:
     needs: ['release-please']
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     uses: ./.github/workflows/ci.yml
   publish:
-    needs: ['release-please', 'ci']
+    needs: ['release-please', 'ci', 'create-tag']
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     uses: ./.github/workflows/publish.yml
     with:
       dry_run: false
       tag: ${{ needs.release-please.outputs.tag_name }}
+
+  publish-release:
+    needs: ['release-please', 'publish']
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+        run: >
+          gh release edit "$TAG_NAME"
+          --repo ${{ github.repository }}
+          --draft=false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,56 +23,14 @@ jobs:
           token: ${{secrets.GITHUB_TOKEN}}
           default-branch: main
 
-  create-tag:
-    needs: ['release-please']
-    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Create release tag
-        env:
-          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
-            echo "Tag ${TAG_NAME} already exists, skipping creation."
-          else
-            echo "Creating tag ${TAG_NAME}."
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git tag "${TAG_NAME}"
-            git push origin "${TAG_NAME}"
-          fi
-
   ci:
     needs: ['release-please']
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     uses: ./.github/workflows/ci.yml
   publish:
-    needs: ['release-please', 'ci', 'create-tag']
+    needs: ['release-please', 'ci']
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     uses: ./.github/workflows/publish.yml
     with:
       dry_run: false
       tag: ${{ needs.release-please.outputs.tag_name }}
-
-  publish-release:
-    needs: ['release-please', 'publish']
-    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Publish release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
-        run: >
-          gh release edit "$TAG_NAME"
-          --repo ${{ github.repository }}
-          --draft=false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,4 +33,3 @@ jobs:
     uses: ./.github/workflows/publish.yml
     with:
       dry_run: false
-      tag: ${{ needs.release-please.outputs.tag_name }}

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -1,0 +1,49 @@
+## Verifying SDK build provenance with GitHub artifact attestations
+
+LaunchDarkly uses [GitHub artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages.
+
+LaunchDarkly publishes provenance about our SDK package builds using [GitHub's `actions/attest` action](https://github.com/actions/attest). These attestations are stored in GitHub's attestation API and can be verified using the [GitHub CLI](https://cli.github.com/).
+
+To verify build provenance attestations, we recommend using the [GitHub CLI `attestation verify` command](https://cli.github.com/manual/gh_attestation_verify). Example usage for verifying SDK packages is included below:
+
+<!-- x-release-please-start-version -->
+```
+# Set the version of the SDK to verify
+SDK_VERSION=2.0.0
+```
+<!-- x-release-please-end -->
+
+```
+# Download the nupkg from NuGet
+$ nuget install LaunchDarkly.Logging -Version $SDK_VERSION -OutputDirectory ./packages
+
+# Verify provenance using the GitHub CLI
+$ gh attestation verify ./packages/LaunchDarkly.Logging.${SDK_VERSION}/LaunchDarkly.Logging.${SDK_VERSION}.nupkg --owner launchdarkly
+```
+
+Below is a sample of expected output.
+
+```
+Loaded digest sha256:... for file://LaunchDarkly.Logging.2.0.0.nupkg
+Loaded 1 attestation from GitHub API
+
+The following policy criteria will be enforced:
+- Predicate type must match:................ https://slsa.dev/provenance/v1
+- Source Repository Owner URI must match:... https://github.com/launchdarkly
+- Subject Alternative Name must match regex: (?i)^https://github.com/launchdarkly/
+- OIDC Issuer must match:................... https://token.actions.githubusercontent.com
+
+✓ Verification succeeded!
+
+The following 1 attestation matched the policy criteria
+
+- Attestation #1
+  - Build repo:..... launchdarkly/dotnet-logging
+  - Build workflow:. .github/workflows/release-please.yml
+  - Signer repo:.... launchdarkly/dotnet-logging
+  - Signer workflow: .github/workflows/release-please.yml
+```
+
+For more information, see [GitHub's documentation on verifying artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#verifying-artifact-attestations-with-the-github-cli).
+
+**Note:** These instructions do not apply when building our SDKs from source.

--- a/README.md
+++ b/README.md
@@ -37,13 +37,17 @@ a8a17f69f1bef56e253fc9166096c907514ab74b812d041faa04712e2bcb243d
 Public Key Token: d9182e4b0afd33e7
 ```
 
+## Verifying build provenance with the SLSA framework
+
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published packages. To learn more, see the [provenance guide](PROVENANCE.md).
+
 ## About LaunchDarkly
  
 * LaunchDarkly is a continuous delivery platform that provides feature flags as a service and allows developers to iterate quickly and safely. We allow you to easily flag your features and manage them from the LaunchDarkly dashboard.  With LaunchDarkly, you can:
     * Roll out a new feature to a subset of your users (like a group of users who opt-in to a beta tester group), gathering feedback and bug reports from real-world use cases.
     * Gradually roll out a feature to an increasing percentage of users, and track the effect that the feature has on key metrics (for instance, how likely is a user to complete a purchase if they have feature A versus feature B?).
     * Turn off a feature that you realize is causing performance problems in production, without needing to re-deploy, or even restart the application with a changed configuration file.
-    * Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan). Disable parts of your application to facilitate maintenance, without taking everything offline.
+    * Grant access to certain features based on user attributes, like payment plan (eg: users on the 'gold' plan get access to more features than users in the 'silver' plan). Disable parts of your application to facilitate maintenance, without taking everything offline.
 * LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies. Check out [our documentation](https://docs.launchdarkly.com/docs) for a complete list.
 * Explore LaunchDarkly
     * [launchdarkly.com](https://www.launchdarkly.com/ "LaunchDarkly Main Website") for more information

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,10 @@
       "release-type": "simple",
       "bootstrap-sha": "b4600d1c993afecd737dad1c85da34908c7d7e50",
       "include-v-in-tag": false,
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "extra-files": [
+        "PROVENANCE.md"
+      ]
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,8 +4,7 @@
       "release-type": "simple",
       "bootstrap-sha": "b4600d1c993afecd737dad1c85da34908c7d7e50",
       "include-v-in-tag": false,
-      "include-component-in-tag": false,
-      "force-tag-creation": true
+      "include-component-in-tag": false
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,8 @@
       "release-type": "simple",
       "bootstrap-sha": "b4600d1c993afecd737dad1c85da34908c7d7e50",
       "include-v-in-tag": false,
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "draft": true
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,6 @@
       "bootstrap-sha": "b4600d1c993afecd737dad1c85da34908c7d7e50",
       "include-v-in-tag": false,
       "include-component-in-tag": false,
-      "draft": true,
       "force-tag-creation": true
     }
   }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,8 @@
       "bootstrap-sha": "b4600d1c993afecd737dad1c85da34908c7d7e50",
       "include-v-in-tag": false,
       "include-component-in-tag": false,
-      "draft": true
+      "draft": true,
+      "force-tag-creation": true
     }
   }
 }


### PR DESCRIPTION
## Summary

Supports GitHub's immutable releases by migrating provenance attestation from `slsa-framework/slsa-github-generator` to `actions/attest@v4`. Since this repo only uses attestation (no binary/artifact uploads to the release), draft releases are **not** needed — `actions/attest@v4` stores attestations via GitHub's attestation API, not as release assets.

**Changes in `.github/workflows/publish.yml`:**

- Removed the separate `provenance` job that called `slsa-framework/slsa-github-generator` and uploaded a `.intoto.jsonl` file as a release asset.
- Added an inline `Attest build provenance` step directly in the `publish` job, using `subject-path: 'nupkgs/*'` to reference built NuGet packages on disk.
- Added `attestations: write` permission.
- Removed unused `tag` input from both `workflow_dispatch` and `workflow_call` triggers.
- Uses `format('{0}', inputs.dry_run) == 'false'` for the dry_run condition to handle both boolean (`workflow_call`) and string (`workflow_dispatch`) input types correctly.

**Changes in `.github/workflows/release-please.yml`:**

- Removed dead `tag_name` output from the `release-please` job (no longer consumed by any downstream job).
- Removed the `tag:` parameter from the `publish.yml` caller.

**Changes in `.github/actions/publish/action.yml`:**

- Removed the `hashes` output and "Hash nuget packages" step. These existed to produce base64-encoded checksums for the old SLSA generator and are no longer needed — `subject-path` lets `actions/attest@v4` compute checksums from files on disk directly.

**New documentation:**

- Added `PROVENANCE.md` with instructions for verifying build provenance using `gh attestation verify`, including example commands and sample output.
- Added a "Verifying build provenance with the SLSA framework" section to `README.md` linking to `PROVENANCE.md`.

## Review & Testing Checklist for Human

- [ ] **Verify `subject-path: 'nupkgs/*'` matches the actual build output**: The composite action runs `dotnet pack --output nupkgs`, producing `.nupkg` and `.snupkg` files. Confirm the glob `nupkgs/*` resolves correctly from the workflow's working directory (the repo root). If the path is relative to a different directory, attestation will silently produce no subjects.
- [ ] **Verify the `PROVENANCE.md` version placeholder**: The file uses `x-release-please-start-version` with `SDK_VERSION=2.0.0`. Confirm this matches the current/next release version and that release-please will update it correctly on future releases.
- [ ] **Test end-to-end with a dry-run or fork release**: The attestation step only executes when `dry_run == 'false'`, so it cannot be validated by CI on a feature branch. Trigger a manual workflow run (with `dry_run: true` first to verify no regressions, then `dry_run: false` on a fork or test tag) to confirm attestation is created successfully and `gh attestation verify` works as documented in `PROVENANCE.md`.

### Notes
- This follows the simplified attestation-only pattern: since `actions/attest@v4` does not modify GitHub releases, no draft release workflow is needed for this repo.
- `force-tag-creation` and `draft` are intentionally **not** set in `release-please-config.json` — they are only needed for repos that upload artifacts to releases.
- The `format('{0}', inputs.dry_run)` pattern stringifies the input regardless of source type, ensuring `== 'false'` works for both `workflow_call` (boolean) and `workflow_dispatch` (string) triggers.

Link to Devin session: https://app.devin.ai/sessions/7d5bda4d9dbe4ae0b950b30a50485e60
Requested by: @keelerm84