### PR TITLE
ci: split release-please into independent release and PR creation steps

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,11 +16,41 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
+      # Create any releases first, then create tags, and then optionally create any new PRs.
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         id: release
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           default-branch: main
+          skip-github-pull-request: true
+
+      # Need the repository content to be able to create and push a tag.
+      - uses: actions/checkout@v4
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+
+      - name: Create release tag
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        env:
+          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            echo "Tag ${TAG_NAME} already exists, skipping creation."
+          else
+            echo "Creating tag ${TAG_NAME}."
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "${TAG_NAME}"
+            git push origin "${TAG_NAME}"
+          fi
+
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
+        if: ${{ steps.release.outputs.release_created != 'true' }}
+        id: release-prs
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          default-branch: main
+          skip-github-release: true
 
   ci:
     needs: ['release-please']

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release-please:
     outputs:
-      releases_created: ${{ steps.release.outputs.releases_created }}
+      release_created: ${{ steps.release.outputs.release_created }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write # Needed if using OIDC to get release secrets.
@@ -54,11 +54,11 @@ jobs:
 
   ci:
     needs: ['release-please']
-    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
     uses: ./.github/workflows/ci.yml
   publish:
     needs: ['release-please', 'ci']
-    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
     uses: ./.github/workflows/publish.yml
     with:
       dry_run: false


### PR DESCRIPTION
## Summary

Splits the release-please action into two sequential passes to support GitHub's immutable releases. This matches the pattern established in [ld-relay PR #622](https://github.com/launchdarkly/ld-relay/pull/622).

**Pass 1** (`skip-github-pull-request: true`): Attempts to create a GitHub release. If a release is created, the workflow checks out the repo and manually creates/pushes the tag (since release-please needs the tag to exist to know a release was already made).

**Pass 2** (`skip-github-release: true`): Only runs if no release was created in pass 1. Creates or updates release-please PRs.

This two-pass approach is required because release-please determines whether to open a new release PR by checking if the tag already exists. Without the split, there's a race where the tag isn't created before release-please tries to evaluate PR state.

## Review & Testing Checklist for Human

- [ ] Verify that `release_created` (singular, used in tag creation conditions) and `releases_created` (plural, used in job output for downstream `ci`/`publish` jobs) are both emitted correctly by release-please for this single-package repo
- [ ] Confirm the tag creation logic is idempotent — the `gh api` check guards against duplicate tag pushes, but verify this matches expected behavior
- [ ] After merging, trigger the workflow on a test push to `main` to confirm release-please PRs are still created correctly (the non-release path via pass 2)

### Notes
- The pinned SHA `16a9c90856f42705d54a6fda1823352bdc62cf38` is unchanged; only the version comment was updated from `# v4` to `# v4.4.0` for accuracy
- Tag creation uses `github-actions[bot]` identity, consistent with the ld-relay reference implementation

Link to Devin session: https://app.devin.ai/sessions/7d5bda4d9dbe4ae0b950b30a50485e60
Requested by: @keelerm84

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release workflow’s control flow and tag creation behavior; a mis-emitted `release_created` output or tag push failure could block `ci`/`publish` from running on release commits.
> 
> **Overview**
> Updates the `Release Please` GitHub Actions workflow to run `release-please` in two passes: first to create a GitHub release (with PR creation disabled), then—only if no release was created—to open/update release PRs (with release creation disabled).
> 
> When a release is created, the workflow now checks out the repo and manually creates/pushes the release tag (idempotently, skipping if the tag already exists). Downstream `ci` and `publish` jobs are gated on the new singular `release_created` output instead of `releases_created`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bb1a72574de27495a46fdb21ba6b31aae27d485. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->