### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Repository Maintainers
+* @launchdarkly/team-sdk-net


### PR DESCRIPTION
## Summary

Add CODEOWNERS file assigning `@launchdarkly/team-sdk-net` as repository maintainers, consistent with other dotnet SDK repos (e.g., `dotnet-core`, `dotnet-eventsource`).

Link to Devin session: https://app.devin.ai/sessions/705dd2d4d8d0457bae513f731d3108ee
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Process-only change with no runtime or application code impact.
> 
> **Overview**
> Adds a **CODEOWNERS** file so all paths (`*`) are owned by `@launchdarkly/team-sdk-net`, aligning this repo with other .NET SDK repositories for automatic review routing and maintainer visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e6d275ff485157e7acb86b4abf1e5536e1cf79c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->