### PR TITLE
fix: add release-please version markers to csproj

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
       "include-v-in-tag": false,
       "include-component-in-tag": false,
       "extra-files": [
+        "src/LaunchDarkly.Logging/LaunchDarkly.Logging.csproj",
         "PROVENANCE.md"
       ]
     }

--- a/src/LaunchDarkly.Logging/LaunchDarkly.Logging.csproj
+++ b/src/LaunchDarkly.Logging/LaunchDarkly.Logging.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!--x-release-please-start-version-->
     <Version>2.0.0</Version>
+    <!--x-release-please-end-->
     <!--
       The reason there's a mechanism here for overriding the target frameworks with
       an environment variable is that we want to be able to run CI tests using .NET


### PR DESCRIPTION
## Summary

release-please doesn't update the `<Version>` in the `.csproj` because the file is missing from `extra-files` and lacks `x-release-please-start-version` / `x-release-please-end` markers. This means the NuGet package would be built with the old version on every release, and `dotnet nuget push` would fail since that version already exists on NuGet.

Adds the csproj to `extra-files` in `release-please-config.json` and wraps the `<Version>` tag with release-please markers — matching how the NLog and MS logging adapters are configured.

Link to Devin session: https://app.devin.ai/sessions/746778111964463bbcfa2ddded90cb85
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release automation and project metadata only; no runtime or API behavior changes.
> 
> **Overview**
> **Fixes release-please so the NuGet package version bumps on each release.**
> 
> `release-please-config.json` now lists `src/LaunchDarkly.Logging/LaunchDarkly.Logging.csproj` under `extra-files`, and the csproj wraps `<Version>` with `x-release-please-start-version` / `x-release-please-end` markers (same pattern as `PROVENANCE.md`). Without this, releases could keep building and pushing `2.0.0`, causing `dotnet nuget push` failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f73aba47a51e970410096a34238c27e9514d883. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->